### PR TITLE
FIX export print type error

### DIFF
--- a/nets/stdcnet.py
+++ b/nets/stdcnet.py
@@ -302,3 +302,4 @@ if __name__ == "__main__":
     y = model(x)
     torch.save(model.state_dict(), 'cat.pth')
     print(f'Number of output nodes: {len(y)}')
+    print('\n'.join([f'Output node {i}\'s size: {node.size()}' for i, node in enumerate(y)]))

--- a/nets/stdcnet.py
+++ b/nets/stdcnet.py
@@ -301,4 +301,4 @@ if __name__ == "__main__":
     x = torch.randn(1,3,224,224)
     y = model(x)
     torch.save(model.state_dict(), 'cat.pth')
-    print(y.size())
+    print(f'Number of output nodes: {len(y)}')


### PR DESCRIPTION
Hi,

Quite a trivial fix in exporting, not sure if it worths a PR...

It seems return type of `STDCNet813`'s `forward` call is tuple.. So probably we could print size one by one?